### PR TITLE
Aligning cerberus cores default from cerberus in krkn-hub

### DIFF
--- a/cerberus/env.sh
+++ b/cerberus/env.sh
@@ -8,7 +8,7 @@ export CERBERUS_WATCH_OPERATORS=${CERBERUS_WATCH_OPERATORS:=True}
 export CERBERUS_WATCH_NAMESPACES=${CERBERUS_WATCH_NAMESPACES:=[openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller-manager, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn]}
 export CERBERUS_TIMEOUT=${CERBERUS_TIMEOUT:=3}
 export CERBERUS_SLEEP=${CERBERUS_SLEEP:=3}
-export CERBERUS_CORES=${CERBERUS_CORES:=1}
+export CERBERUS_CORES=${CERBERUS_CORES:=.5}
 export CHUNK_SIZE=${CHUNK_SIZE:=100}
 export CERBERUS_ITERATIONS=${CERBERUS_ITERATIONS:=5}
 export CERBERUS_DAEMON_MODE=${CERBERUS_DAEMON_MODE:=True}

--- a/docs/cerberus.md
+++ b/docs/cerberus.md
@@ -29,6 +29,6 @@ CERBERUS_TIMEOUT        | Number of seconds before requests fail                
 CERBERUS_SLEEP          | Number of seconds between iterations of Cerberus                      | 3                                    |
 CERBERUS_ITERATIONS     | Number of iterations to run                                           | 5                                    |
 CERBERUS_DAEMON_MODE    | Infinitely run cerberus on cluster, will ignore iterations if this is set to true               | 3                                    |
-CERBERUS_CORES          | Set the fraction of cores to be used for multiprocessing              | 1                                    |
+CERBERUS_CORES          | Set the fraction of cores to be used for multiprocessing              | .5                                    |
 INSPECT_COMPONENTS      | Enable it only when OpenShift client is supported to run; collects logs, events and metrics of failed components | False  | 
 CHUNK_SIZE              | Set the number of objects to return in one call to the kuberenetes API |100 | 


### PR DESCRIPTION
Need to align default value here to have the default cerberus cores to be .5 which is the same as [line](https://github.com/redhat-chaos/cerberus/blob/0ce6f371d8577ea50d4ecd080f5b998884cf91d9/start_cerberus.py#L97)

Having this variable set to 1 takes up too much memory/cpu in jenkins agents and causes the agent to get destroyed before run finishes 