### PR TITLE
Add support for VMware node scenarios

### DIFF
--- a/docs/node-scenarios.md
+++ b/docs/node-scenarios.md
@@ -28,13 +28,15 @@ ex.)
 
 Parameter               | Description                                                           | Default
 ----------------------- | -----------------------------------------------------------------     | ------------------------------------ |
-ACTION                  | Action can be one of the [following](https://github.com/cloud-bulldozer/kraken/blob/master/docs/node_scenarios.md) | node_stop_start_scenario |
+ACTION                  | Action can be one of the [following](https://github.com/cloud-bulldozer/kraken/blob/master/docs/node_scenarios.md) | node_stop_start_scenario for aws and node_stop_scenario for vmware |
 LABEL_SELECTOR          | Node label to target                                                  | node-role.kubernetes.io/worker       |
 NODE_NAME               | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma      | ""                                   |
 INSTANCE_COUNT          | Targeted instance count matching the label selector                   | 1                                    |
 RUNS                    | Iterations to perform action on a single node                         | 1                                    |
-CLOUD_TYPE              | Cloud platform on top of which cluster is running, [supported cloud platforms](https://github.com/cloud-bulldozer/kraken/blob/master/docs/node_scenarios.md)                     | aws |
+CLOUD_TYPE              | Cloud platform on top of which cluster is running, supported platforms - aws or vmware                     | aws |
 TIMEOUT                 | Duration to wait for completion of node scenario injection             | 180                                |
+VERIFY_SESSION          | Only needed for vmware - Set to True if you want to verify the vSphere client session using certificates    | False                               |
+SKIP_OPENSHIFT_CHECKS   | Only needed for vmware - Set to True if you don't want to wait for the status of the nodes to change on OpenShift before passing the scenario  | False |
 CERBERUS_ENABLED        | Set this to true if cerberus is running and monitoring the cluster    | False                                |
 CERBERUS_URL            | URL to poll for the go/no-go signal                                   | http://0.0.0.0:8080                  |
 WAIT_DURATION           | Duration in seconds to wait between each chaos scenario               | 60                                   |
@@ -58,6 +60,16 @@ Amazon Web Services
 $ export AWS_ACCESS_KEY_ID=<>
 $ export AWS_SECRET_ACCESS_KEY=<>
 $ export AWS_DEFAULT_REGION=<>
+```
+
+VMware Vsphere
+```
+$ export VSPHERE_IP=<vSphere_client_IP_address>
+
+$ export VSPHERE_USERNAME=<vSphere_client_username>
+
+$ export VSPHERE_PASSWORD=<vSphere_client_password>
+
 ```
 
 Google Cloud Platform

--- a/node-scenarios/Dockerfile
+++ b/node-scenarios/Dockerfile
@@ -17,5 +17,6 @@ COPY env.sh /root/main_env.sh
 COPY node-scenarios/run.sh /root/run.sh
 COPY common_run.sh /root/common_run.sh
 COPY node-scenarios/node_scenario.yaml.template /root/kraken/scenarios/node_scenario.yaml.template
-COPY node-scenarios/vmware_node_scenario.yaml.template /root/kraken/scenarios/node_scenario.yaml.template
+#COPY node-scenarios/vmware_node_scenario.yaml.template /root/kraken/scenarios/node_scenario.yaml.template
+COPY node-scenarios/vmware_node_scenario.yaml.template /root/kraken/scenarios/vmware_node_scenario.yaml.template
 ENTRYPOINT /root/run.sh

--- a/node-scenarios/Dockerfile
+++ b/node-scenarios/Dockerfile
@@ -17,5 +17,5 @@ COPY env.sh /root/main_env.sh
 COPY node-scenarios/run.sh /root/run.sh
 COPY common_run.sh /root/common_run.sh
 COPY node-scenarios/node_scenario.yaml.template /root/kraken/scenarios/node_scenario.yaml.template
-
+COPY node-scenarios/vmware_node_scenario.yaml.template /root/kraken/scenarios/node_scenario.yaml.template
 ENTRYPOINT /root/run.sh

--- a/node-scenarios/env.sh
+++ b/node-scenarios/env.sh
@@ -11,3 +11,5 @@ export TIMEOUT=${TIMEOUT:=180}
 export SCENARIO_TYPE=${SCENARIO_TYPE:=node_scenarios}
 export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/node_scenario.yaml}
 export SCENARIO_POST_ACTION=${SCENARIO_POST_ACTION:=""}
+export VERIFY_SESSION=${VERIFY_SESSION:="false"}
+export SKIP_OPENSHIFT_CHECKS=${SKIP_OPENSHIFT_CHECKS:="false"}

--- a/node-scenarios/run.sh
+++ b/node-scenarios/run.sh
@@ -10,7 +10,13 @@ source /root/common_run.sh
 checks
 
 # Substitute config with environment vars defined
-envsubst < /root/kraken/scenarios/node_scenario.yaml.template > /root/kraken/scenarios/node_scenario.yaml
+if [[ $CLOUD_TYPE == "vmware"]]; then
+  envsubst < /root/kraken/scenarios/vmware_node_scenario.yaml.template > /root/kraken/scenarios/node_scenario.yaml
+  export SCENARIO_TYPE="plugin_scenarios"
+  export ACTION=${ACTION:=node_stop_scenario"}
+else
+  envsubst < /root/kraken/scenarios/node_scenario.yaml.template > /root/kraken/scenarios/node_scenario.yaml
+fi
 envsubst < /root/kraken/config/config.yaml.template > /root/kraken/config/node_scenario_config.yaml
 
 # Run Kraken

--- a/node-scenarios/run.sh
+++ b/node-scenarios/run.sh
@@ -10,10 +10,10 @@ source /root/common_run.sh
 checks
 
 # Substitute config with environment vars defined
-if [[ $CLOUD_TYPE == "vmware"]]; then
+if [[ "$CLOUD_TYPE" == "vmware" ]]; then
   envsubst < /root/kraken/scenarios/vmware_node_scenario.yaml.template > /root/kraken/scenarios/node_scenario.yaml
   export SCENARIO_TYPE="plugin_scenarios"
-  export ACTION=${ACTION:=node_stop_scenario"}
+  export ACTION=${ACTION:="node_stop_scenario"}
 else
   envsubst < /root/kraken/scenarios/node_scenario.yaml.template > /root/kraken/scenarios/node_scenario.yaml
 fi

--- a/node-scenarios/vmware_node_scenario.yaml.template
+++ b/node-scenarios/vmware_node_scenario.yaml.template
@@ -1,0 +1,16 @@
+- id: $ACTION
+  config:
+    # Node on which scenario has to be injected; can set multiple names separated by comma
+    name: $NODE_NAME
+    # When node_name is not specified, a node with matching label_selector is selected for node chaos scenario injection                           
+    label_selector: $LABEL_SELECTOR 
+    # Number of times to inject each scenario under actions (will perform on same node each time)
+    runs: $RUNS                                                          
+    # Number of nodes to perform action/select that match the label selector
+    instance_count: $INSTANCE_COUNT
+    # Duration to wait for completion of node scenario injection              
+    timeout: $TIMEOUT
+    # Set to True if you want to verify the vSphere client session using certificates; else False
+    verify_session: $VERIFY_SESSION
+    # Set to True if you don't want to wait for the status of the nodes to change on OpenShift before passing the scenario
+    skip_openshift_checks: $SKIP_OPENSHIFT_CHECKS


### PR DESCRIPTION
This commit enables support for VMware provider to run various supported
node chaos scenarios.

Fixes https://github.com/redhat-chaos/krkn-hub/issues/59