### PR TITLE
power-outages/post_action.py: address B506 report

### DIFF
--- a/power-outages/post_action.py
+++ b/power-outages/post_action.py
@@ -20,7 +20,7 @@ def run(cmd):
 # Get cluster operators and return yaml
 def get_cluster_operators():
     operators_status = run("kubectl get co -o yaml")
-    status_yaml = yaml.load(operators_status, Loader=yaml.FullLoader)
+    status_yaml = yaml.safe_load(operators_status, Loader=yaml.FullLoader)
     return status_yaml
 
 


### PR DESCRIPTION
bandit reported:

```
>> Issue: [B506:yaml_load] Use of unsafe yaml load. Allows instantiation of arbitrary objects. Consider yaml.safe_load().
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   Location: ./power-outages/post_action.py:23:18
   More Info: https://bandit.readthedocs.io/en/1.7.4/plugins/b506_yaml_load.html
22	    operators_status = run("kubectl get co -o yaml")
23	    status_yaml = yaml.load(operators_status, Loader=yaml.FullLoader)
24	    return status_yaml
```

This PR addresses the issue.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>