### PR TITLE
common_run: address shellcheck issues

### DIFF
--- a/common_run.sh
+++ b/common_run.sh
@@ -2,14 +2,14 @@
 
 # Logging format
 log() {
-  echo -e "\033[1m$(date "+%d-%m-%YT%H:%M:%S") ${@}\033[0m"
+  echo -e "\033[1m$(date "+%d-%m-%YT%H:%M:%S") ${*}\033[0m"
 }
 
 # Check if oc is installed
 check_oc() {
   log "Checking if OpenShift client is installed"
-  which oc &>/dev/null
-  if [[ $? != 0 ]]; then
+  if ! which oc;
+  then
     log "Looks like OpenShift client is not installed, please install before continuing"
     log "Exiting"
     exit 1
@@ -19,8 +19,8 @@ check_oc() {
 # Check if kubectl is installed
 check_kubectl() {
   log "Checking if kubernetes client is installed"
-  which kubectl &>/dev/null
-  if [[ $? != 0 ]]; then
+  if ! which kubectl;
+  then
     log "Looks like Kubernetes client is not installed, please install before continuing"
     log "Exiting"
     exit 1
@@ -29,8 +29,8 @@ check_kubectl() {
 
 # Check if cluster exists and print the clusterversion under test
 check_cluster_version() {
-  kubectl get clusterversion
-  if [[ $? -ne 0 ]]; then
+  if ! kubectl get clusterversion;
+  then
     log "Unable to connect to the cluster, please check if it's up and make sure the KUBECONFIG is set correctly"
     exit 1
   fi


### PR DESCRIPTION
fixed:
- [SC2181](https://www.shellcheck.net/wiki/SC2181) Check exit code directly with e.g. `if mycmd;`, not indirectly with `$?`.

- [SC2145](https://www.shellcheck.net/wiki/SC2145) Argument mixes string and array. Use `*` or separate argument.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>