### PR TITLE
Tweak the container recovery checks to be more aggresive

### DIFF
--- a/container-scenarios/env.sh
+++ b/container-scenarios/env.sh
@@ -3,7 +3,7 @@
 # Vars and respective defaults
 export NAMESPACE=${NAMESPACE:="openshift-etcd"}
 export LABEL_SELECTOR=${LABEL_SELECTOR:="k8s-app=etcd"}
-export RETRY_WAIT=${RETRY_WAIT:=120}
+export RETRY_WAIT=${RETRY_WAIT:=60}
 export DISRUPTION_COUNT=${DISRUPTION_COUNT:=1}
 export CONTAINER_NAME=${CONTAINER_NAME:=etcd}
 export ACTION=${ACTION:="kill 1"}

--- a/docs/container-scenarios.md
+++ b/docs/container-scenarios.md
@@ -35,6 +35,7 @@ LABEL_SELECTOR          | Label of the container(s) to target                   
 DISRUPTION_COUNT        | Number of container to disrupt                                        | 1                                    |
 CONTAINER_NAME          | Name of the container to disrupt                                      | etcd                                 |
 ACTION                  | Action to run. For example kill 1 ( hang up ) or kill 9               | kill 1                               |
+RETRY_WAIT              | Time to wait before checking if all containers that were affected recover properly | 60                      |
 
 **NOTE** In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/root/kraken/config/metrics-aggregated.yaml` and `/root/kraken/config/alerts`. For example:
 ```


### PR DESCRIPTION
This commit updates the container recovery wait time to 60 seconds and also add the param to the readme.