### PR TITLE
Prow ci-operator file needed

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.18


### PR DESCRIPTION
Need this file to build the base of the krkn-hub image: 

https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image

Error: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/34844/rehearse-34844-periodic-ci-redhat-chaos-krkn-hub-main-krkn-hub-tests/1622618867836653568