### PR TITLE
Unset KUBECONFIG to avoid overriding the context inside the container

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -17,3 +17,6 @@ export DEPLOY_DASHBOARDS=${DEPLOY_DASHBOARDS:=False}
 export CAPTURE_METRICS=${CAPTURE_METRICS:=False}
 export ENABLE_ALERTS=${ENABLE_ALERTS:=False}
 export ES_SERVER=${ES_SERVER:=http://0.0.0.0:9200}
+
+# Unset KUBECONFIG to make sure mounted kubeconfig is used
+unset KUBECONFIG


### PR DESCRIPTION
This will make sure users won't hit the edge case where their KUBECONFIG context gets passed to the container given that we use env vars defined on the host where the podman command is initiated.