### PR TITLE
Support for vanila k8s

### DIFF
--- a/common_run.sh
+++ b/common_run.sh
@@ -29,11 +29,12 @@ check_kubectl() {
 
 # Check if cluster exists and print the clusterversion under test
 check_cluster_version() {
-  if ! kubectl get clusterversion;
-  then
+  if ! kubectl version;
+  then 
     log "Unable to connect to the cluster, please check if it's up and make sure the KUBECONFIG is set correctly"
     exit 1
   fi
+  kubectl get clusterversion
 }
 
 


### PR DESCRIPTION
Vanila k8s clusters dont have **clusterversion** objects:
```
$ kubectl get clusterversion
error: the server doesn't have a resource type "clusterversion"
```
So https://github.com/redhat-chaos/krkn-hub/blob/main/common_run.sh#L30-37 is going to fail and to prevent the run of the test.

Adding `kubectl version` as a more generic way to check if the cluster exists:
```
$ kubectl version
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"1", Minor:"25", GitVersion:"v1.25.2", GitCommit:"b05f7d40f9a2dac30771be620e9e9148d26ffd07", GitTreeState:"clean", BuildDate:"2023-02-28T00:59:02Z", GoVersion:"go1.19.4", Compiler:"gc", Platform:"linux/amd64"}
Kustomize Version: v4.5.7
Server Version: version.Info{Major:"1", Minor:"25", GitVersion:"v1.25.3", GitCommit:"434bfd82814af038ad94d62ebe59b133fcb50506", GitTreeState:"clean", BuildDate:"2022-10-25T19:35:11Z", GoVersion:"go1.19.2", Compiler:"gc", Platform:"linux/amd64"}
```