### PR TITLE
Add support for pod network chaos scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Scenario   | Description | Working
 [Power Outages](docs/power-outages.md) | Shuts down the cluster for the specified duration and turns it back on to check the cluster health | :heavy_check_mark: |
 [PVC disk fill](docs/pvc-scenarios.md) | Fills up a given PersistenVolumeClaim by creating a temp file on the PVC from a pod associated with it | :heavy_check_mark: |
 [Network Chaos](docs/network-chaos.md) | Introduces network latency, packet loss, bandwidth restriction in the egress traffic of a Node's interface using tc and Netem | :heavy_check_mark: | 
+[Pod Network Chaos][docs/pod-network-chaos.md) | Introducs network chaos at pod level | :heavy_check_mark: |
 
 
 ### Set Up 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,3 +70,8 @@ services:
         context: ./
         dockerfile: ./network-chaos/Dockerfile
       image: quay.io/redhat-chaos/krkn-hub:network-chaos
+    pod-network-chaos:
+      build:
+        context: ./
+        dockerfile: ./pod-network-chaos/Dockerfile
+      image: quay.io/redhat-chaos/krkn-hub:pod-network-chaos

--- a/docs/pod-network-chaos.md
+++ b/docs/pod-network-chaos.md
@@ -1,0 +1,47 @@
+### Pod Network Chaos Scenarios
+This scenario runs network chaos at the pod level on a Kubernetes/OpenShift cluster.
+
+#### Run
+
+If enabling [Cerberus](https://github.com/redhat-chaos/krkn#kraken-scenario-passfail-criteria-and-report) to monitor the cluster and pass/fail the scenario post chaos, refer [docs](https://github.com/redhat-chaos/krkn-hub/tree/main/docs/cerberus.md). Make sure to start it before injecting the chaos and set `CERBERUS_ENABLED` environment variable for the chaos injection container to autoconnect.
+
+```
+$ podman run --name=<container_name> --net=host --env-host=true -v <path-to-kube-config>:/root/.kube/config:Z -d quay.io/redhat-chaos/krkn-hub:pod-network-chaos
+$ podman logs -f <container_name or container_id> # Streams Kraken logs
+$ podman inspect <container-name or container-id> --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
+```
+
+```
+$ docker run $(./get_docker_params.sh) --name=<container_name> --net=host -v <path-to-kube-config>:/root/.kube/config:Z -d quay.io/redhat-chaos/krkn-hub:pod-network-chaos
+OR 
+$ docker run -e <VARIABLE>=<value> --name=<container_name> --net=host -v <path-to-kube-config>:/root/.kube/config:Z -d quay.io/redhat-chaos/krkn-hub:pod-network-chaos
+
+$ docker logs -f <container_name or container_id> # Streams Kraken logs
+$ docker inspect <container-name or container-id> --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
+```
+
+#### Supported parameters
+
+The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:
+
+ex.) 
+`export <parameter_name>=<value>`
+
+See list of variables that apply to all scenarios [here](all_scenarios_env.md) that can be used/set in addition to these scenario specific variables
+
+Parameter               | Description                                                           | Default
+----------------------- | -----------------------------------------------------------------     | ------------------------------------ |
+NAMESPACE               | Required - Namespace of the pod to which filter need to be applied    | ""                                     |
+LABEL_SELECTOR          | Label of the pod(s) to target                                         | ""                                   | 
+POD_NAME                | When label_selector is not specified, pod matching the name will be selected for the chaos scenario | "" |
+INSTANCE_COUNT          | Number of pods to perform action/select that match the label selector | 1 |
+TRAFFIC_TYPE            | List of directions to apply filters - egress/ingress ( needs to be a list ) | [ingress, egress] |
+INGRESS_PORTS           | Ingress ports to block ( needs to be a list ) | [] i.e all ports |
+EGRESS_PORTS            | Egress ports to block ( needs to be a list ) | [] i.e all ports |
+WAIT_DURATION           | Ensure that it is at least about twice of test_duration | 300 |
+TEST_DURATION           | Duration of the test run | 120 |
+
+**NOTE** In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/root/kraken/config/metrics-aggregated.yaml` and `/root/kraken/config/alerts`. For example:
+```
+$ podman run --name=<container_name> --net=host --env-host=true -v <path-to-custom-metrics-profile>:/root/kraken/config/metrics-aggregated.yaml -v <path-to-custom-alerts-profile>:/root/kraken/config/alerts -v <path-to-kube-config>:/root/.kube/config:Z -d quay.io/redhat-chaos/krkn-hub:pod-network-chaos
+```

--- a/pod-network-chaos/Dockerfile
+++ b/pod-network-chaos/Dockerfile
@@ -1,0 +1,21 @@
+# Dockerfile for kraken
+
+FROM quay.io/redhat-chaos/krkn:latest
+
+MAINTAINER Red Hat Chaos Engineering Team
+
+ENV KUBECONFIG /root/.kube/config
+
+# Install dependencies
+RUN yum install -y which
+
+# Copy configurations
+COPY config.yaml.template /root/kraken/config/config.yaml.template
+COPY metrics_config.yaml.template /root/kraken/config/kube_burner.yaml.template
+COPY pod-network-chaos/env.sh /root/env.sh
+COPY env.sh /root/main_env.sh
+COPY pod-network-chaos/run.sh /root/run.sh
+COPY common_run.sh /root/common_run.sh
+COPY pod-network-chaos/pod_network_scenario.yaml.template /root/kraken/scenarios/pod_network_scenario.yaml.template
+
+ENTRYPOINT /root/run.sh

--- a/pod-network-chaos/README.md
+++ b/pod-network-chaos/README.md
@@ -1,0 +1,3 @@
+# Pod Network Chaos Scenario Docs
+
+See [doc](https://github.com/redhat-chaos/krkn-hub/blob/main/docs/pod-network-chaos.md) for how to run and all the variables listed

--- a/pod-network-chaos/env.sh
+++ b/pod-network-chaos/env.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Vars and respective defaults
+export NAMESPACE=${NAMESPACE:=""}
+export TRAFFIC_TYPE=${TRAFFIC_TYPE:=[ingress, egress]}
+export INGRESS_PORTS=${INGRESS_PORTS:=[]}
+export EGRESS_PORTS=${EGRESS_PORTS:=[]}
+export WAIT_DURATION=${WAIT_DURATION:=360}
+export LABEL_SELECTOR=${LABEL_SELECTOR:=""}
+export POD_NAME=${POD_NAME:=""}
+export INSTANCE_COUNT=${INSTANCE_COUNT:=1}
+export TEST_DURATION=${TEST_DURATION:=120}
+export SCENARIO_TYPE=${SCENARIO_TYPE:=plugin_scenarios}
+export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/pod_network_scenario.yaml}
+export SCENARIO_POST_ACTION=${SCENARIO_POST_ACTION:=""}

--- a/pod-network-chaos/pod_network_scenario.yaml.template
+++ b/pod-network-chaos/pod_network_scenario.yaml.template
@@ -1,0 +1,10 @@
+- id: pod_network_outage
+  config:
+    namespace: $NAMESPACE
+    direction: $TRAFFIC_TYPE             
+    ingress_ports: $INGRESS_PORTS
+    egress_ports: $EGRESS_PORTS                     
+    label_selector: $LABEL_SELECTOR
+    instance_count: $INSTANCE_COUNT
+    wait_duration: $WAIT_DURATION
+    test_duration: $TEST_DURATION

--- a/pod-network-chaos/run.sh
+++ b/pod-network-chaos/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+# Source env.sh to read all the vars
+source /root/main_env.sh
+source /root/env.sh
+
+ls -la /root/.kube
+
+source /root/common_run.sh
+checks
+config_setup
+
+# Substitute config with environment vars defined
+envsubst < /root/kraken/scenarios/pod_network_scenario.yaml.template > /root/kraken/scenarios/pod_network_scenario.yaml
+envsubst < /root/kraken/config/config.yaml.template > /root/kraken/config/pod_network_scenario_config.yaml
+
+# Validate if namespace parameter is set
+if [[ -z $NAMESPACE ]]; then
+  echo "Requires NAMASPACE parameter to be set, please check"
+  exit 1
+fi
+
+# Run Kraken
+cd /root/kraken
+
+cat /root/kraken/config/pod_network_scenario_config.yaml
+cat /root/kraken/scenarios/pod_network_scenario.yaml
+
+python3 run_kraken.py --config=/root/kraken/config/pod_network_scenario_config.yaml


### PR DESCRIPTION
This commit adds the ability for user to block ingress/egress ports
for the selected pods now that Kraken supports it: https://github.com/redhat-chaos/krkn/pull/398. 
Next steps would be to support traffic shaping for example latency, packet loss etc.

