### PR TITLE
Adding cerberus prow options

### DIFF
--- a/cerberus/Dockerfile_prow
+++ b/cerberus/Dockerfile_prow
@@ -1,0 +1,20 @@
+# Dockerfile for cerberus in prow
+
+FROM registry.ci.openshift.org/chaos/cerberus:latest as cerberus
+
+LABEL maintainer="Red Hat Chaos Engineering Team"
+
+# Install dependencies
+RUN yum install -y which
+
+# Copy configurations
+ADD . /cerberus
+
+RUN yum install -y python3 python3-pip python3-devel git diffutils && \
+    python3 -m pip install --upgrade pip
+
+ENV PYTHONPATH=/cerberus/packages:$PYTHONPATH PYTHONUNBUFFERED=1
+
+RUN ls
+
+WORKDIR /cerberus

--- a/cerberus/prow_run.sh
+++ b/cerberus/prow_run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -ex
+
+ls
+
+# Source env.sh to read all the vars
+source env.sh
+
+export KUBECONFIG=$KRKN_KUBE_CONFIG
+
+oc version 
+
+cat $KRKN_KUBE_CONFIG
+
+oc config view
+source env.sh
+source cerberus/env.sh
+
+crb_loc=/root/cerberus
+
+# Substitute config with environment vars defined
+envsubst < cerberus/config/cerberus.yaml.template > cerberus/config/config.yaml
+
+cat config/config.yaml
+
+python3 $crb_loc/start_cerberus.py --config=config/config.yaml


### PR DESCRIPTION
Want to be able to run cerberus as an [observer](https://docs.ci.openshift.org/docs/internals/observer-pods/) in prow. With that we need to be able to have a dockerfile to load the folders and run it properly 

Correlated to PR: https://github.com/redhat-chaos/cerberus/pull/198