### PR TITLE
adding cerberus folder

### DIFF
--- a/cerberus/prow_run.sh
+++ b/cerberus/prow_run.sh
@@ -23,6 +23,6 @@ crb_loc=/root/cerberus
 # Substitute config with environment vars defined
 envsubst < cerberus/cerberus.yaml.template > cerberus/config.yaml
 
-cat config/config.yaml
+cat cerberus/config.yaml
 
 python3 $crb_loc/start_cerberus.py --config=cerberus/config.yaml


### PR DESCRIPTION
Wrong folder :( 

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/39697/rehearse-39697-periodic-ci-redhat-chaos-krkn-hub-main-krkn-hub-tests/1671243300025143296/artifacts/krkn-hub-tests/redhat-chaos-cerberus/build-log.txt
```
+ envsubst
./cerberus/prow_run.sh: line 24: cerberus/config.yaml: Permission denied
```