### PR TITLE
Cerberus prow

### DIFF
--- a/cerberus/Dockerfile_prow
+++ b/cerberus/Dockerfile_prow
@@ -10,7 +10,7 @@ RUN yum install -y which
 # Copy configurations
 ADD . /cerberus
 
-RUN yum install -y python3 python3-pip python3-devel git diffutils && \
+RUN yum install -y python3 python3-pip python3-devel git diffutils gettext && \
     python3 -m pip install --upgrade pip
 
 ENV PYTHONPATH=/cerberus/packages:$PYTHONPATH PYTHONUNBUFFERED=1

--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -10,7 +10,7 @@ RUN yum install -y which
 # Copy configurations
 ADD . /krkn-hub
 
-RUN yum install -y python3 python3-pip python3-devel git diffutils && \
+RUN yum install -y python3 python3-pip python3-devel git diffutils gettext && \
     python3 -m pip install --upgrade pip
 
 ENV PYTHONPATH=/krkn-hub/packages:$PYTHONPATH PYTHONUNBUFFERED=1


### PR DESCRIPTION
Missing envsubst command 

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/39697/rehearse-39697-periodic-ci-redhat-chaos-krkn-hub-main-krkn-hub-tests/1671591986735353856/artifacts/krkn-hub-tests/redhat-chaos-cerberus/build-log.txt
`./cerberus/prow_run.sh: line 26: envsubst: command not found`

Found this in how to install: https://www.thegeekdiary.com/envsubst-command-not-found/