### PR TITLE
Use python3.9 explicitly to avoid dependency issues

### DIFF
--- a/application-outages/run.sh
+++ b/application-outages/run.sh
@@ -20,4 +20,4 @@ envsubst < /root/kraken/config/config.yaml.template > /root/kraken/config/app_ou
 cd /root/kraken
 
 
-python3 run_kraken.py --config=config/app_outage_config.yaml
+python3.9 run_kraken.py --config=config/app_outage_config.yaml

--- a/container-scenarios/run.sh
+++ b/container-scenarios/run.sh
@@ -22,4 +22,4 @@ cat config/container_scenario_config.yaml
 cat scenarios/container_scenario.yaml
 
 
-python3 run_kraken.py --config=config/container_scenario_config.yaml
+python3.9 run_kraken.py --config=config/container_scenario_config.yaml

--- a/namespace-scenarios/run.sh
+++ b/namespace-scenarios/run.sh
@@ -20,4 +20,4 @@ cd /root/kraken
 cat scenarios/namespace_scenario.yaml
 cat config/namespace_config.yaml
 
-python3 run_kraken.py --config=config/namespace_config.yaml
+python3.9 run_kraken.py --config=config/namespace_config.yaml

--- a/network-chaos/run.sh
+++ b/network-chaos/run.sh
@@ -27,4 +27,4 @@ envsubst < /root/kraken/config/config.yaml.template > /root/kraken/config/networ
 
 # Run Kraken
 cd /root/kraken
-python3 run_kraken.py --config=config/network_chaos_config.yaml
+python3.9 run_kraken.py --config=config/network_chaos_config.yaml

--- a/node-cpu-hog/run.sh
+++ b/node-cpu-hog/run.sh
@@ -25,6 +25,6 @@ cat config/cpu_config.yaml
 
 cat scenarios/arcaflow/cpu-hog/input.yaml
 
-python3 run_kraken.py --config=config/cpu_config.yaml
+python3.9 run_kraken.py --config=config/cpu_config.yaml
 
 

--- a/node-memory-hog/run.sh
+++ b/node-memory-hog/run.sh
@@ -27,4 +27,4 @@ cat config/mem_config.yaml
 
 cat scenarios/arcaflow/memory-hog/input.yaml
 
-python3 run_kraken.py --config=config/mem_config.yaml
+python3.9 run_kraken.py --config=config/mem_config.yaml

--- a/node-scenarios/run.sh
+++ b/node-scenarios/run.sh
@@ -26,4 +26,4 @@ cat config/node_scenario_config.yaml
 
 cat scenarios/node_scenario.yaml
 
-python3 run_kraken.py --config=config/node_scenario_config.yaml
+python3.9 run_kraken.py --config=config/node_scenario_config.yaml

--- a/pod-network-chaos/run.sh
+++ b/pod-network-chaos/run.sh
@@ -28,4 +28,4 @@ cd /root/kraken
 cat /root/kraken/config/pod_network_scenario_config.yaml
 cat /root/kraken/scenarios/pod_network_scenario.yaml
 
-python3 run_kraken.py --config=/root/kraken/config/pod_network_scenario_config.yaml
+python3.9 run_kraken.py --config=/root/kraken/config/pod_network_scenario_config.yaml

--- a/pod-scenarios/run.sh
+++ b/pod-scenarios/run.sh
@@ -26,4 +26,4 @@ cd /root/kraken
 cat /root/kraken/config/pod_scenario_config.yaml
 cat /root/kraken/scenarios/pod_scenario.yaml
 
-python3 run_kraken.py --config=/root/kraken/config/pod_scenario_config.yaml
+python3.9 run_kraken.py --config=/root/kraken/config/pod_scenario_config.yaml

--- a/power-outages/run.sh
+++ b/power-outages/run.sh
@@ -21,4 +21,4 @@ cat config/shut_down_config.yaml
 
 cat scenarios/cluster_shut_down_scenario.yml
 
-python3 run_kraken.py --config=config/shut_down_config.yaml
+python3.9 run_kraken.py --config=config/shut_down_config.yaml

--- a/prow/container-scenarios/prow_run.sh
+++ b/prow/container-scenarios/prow_run.sh
@@ -29,4 +29,4 @@ envsubst < config.yaml.template > container_scenario_config.yaml
 # Run Kraken
 cat container_scenario_config.yaml
 cat container-scenarios/container_scenario.yaml
-python3 $krkn_loc/run_kraken.py --config=container_scenario_config.yaml
+python3.9 $krkn_loc/run_kraken.py --config=container_scenario_config.yaml

--- a/prow/pod-scenarios/prow_run.sh
+++ b/prow/pod-scenarios/prow_run.sh
@@ -34,4 +34,4 @@ envsubst < config.yaml.template > pod_scenario_config.yaml
 cat pod_scenario_config.yaml
 cat pod-scenarios/pod_scenario.yaml
 
-python3 $krn_loc/run_kraken.py --config=pod_scenario_config.yaml
+python3.9 $krn_loc/run_kraken.py --config=pod_scenario_config.yaml

--- a/pvc-scenario/run.sh
+++ b/pvc-scenario/run.sh
@@ -20,4 +20,4 @@ envsubst < /root/kraken/config/config.yaml.template > /root/kraken/config/config
 cd /root/kraken
 
 
-python3 run_kraken.py --config config/config.yaml
+python3.9 run_kraken.py --config config/config.yaml

--- a/time-scenarios/run.sh
+++ b/time-scenarios/run.sh
@@ -16,4 +16,4 @@ envsubst < /root/kraken/config/config.yaml.template > /root/kraken/config/time_c
 
 # Run Kraken
 cd /root/kraken
-python3 run_kraken.py --config=config/time_config.yaml
+python3.9 run_kraken.py --config=config/time_config.yaml

--- a/zone-outages/run.sh
+++ b/zone-outages/run.sh
@@ -16,4 +16,4 @@ envsubst < /root/kraken/config/config.yaml.template > /root/kraken/config/zone_c
 
 # Run Kraken
 cd /root/kraken
-python3 run_kraken.py --config=config/zone_config.yaml
+python3.9 run_kraken.py --config=config/zone_config.yaml


### PR DESCRIPTION
Kraken explicitly uses python3.9 and pip3.9 for running and installing dependencies. This commit makes sure to run the scenarios using python3.9 to match the krkn source.