### PR TITLE
Run Kraken from /tmp dir instead of root

### DIFF
--- a/prow/cpu-hog/prow_run.sh
+++ b/prow/cpu-hog/prow_run.sh
@@ -8,7 +8,9 @@ ls
 source env.sh
 
 export KUBECONFIG=$KRKN_KUBE_CONFIG
-krkn_loc=/root/kraken
+# Move kraken from root dir to tmp to avoid permissions issues in prow until fixed in base image
+cp -r /root/kraken /tmp/kraken
+krkn_loc=/tmp/kraken
 SCENARIO_FOLDER="$krkn_loc/scenarios/arcaflow/cpu-hog"
 
 # cluster details

--- a/prow/memory-hog/prow_run.sh
+++ b/prow/memory-hog/prow_run.sh
@@ -8,7 +8,9 @@ ls
 source env.sh
 
 export KUBECONFIG=$KRKN_KUBE_CONFIG
-krkn_loc=/root/kraken
+# Move kraken from root dir to tmp to avoid permissions issues in prow until fixed in base image
+cp -r /root/kraken /tmp/kraken
+krkn_loc=/tmp/kraken
 SCENARIO_FOLDER="$krkn_loc/scenarios/arcaflow/memory-hog"
 
 # cluster details


### PR DESCRIPTION
This is needed to avoid permission issues in prow env.