### PR TITLE
Disable cerberus prow image build

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,11 +5,6 @@ services:
         context: ./
         dockerfile: ./cerberus/Dockerfile
       image: quay.io/redhat-chaos/cerberus:kraken-hub
-    cerberus-prow:
-      build:
-        context: ./
-        dockerfile: ./cerberus/Dockerfile_prow
-      image: quay.io/redhat-chaos/cerberus:prow
     pod-scenarios:
       build:
           context: ./


### PR DESCRIPTION
This is temporary until we add in the token to access the registry.