### PR TITLE
Upating base image

### DIFF
--- a/cerberus/Dockerfile_prow
+++ b/cerberus/Dockerfile_prow
@@ -1,6 +1,6 @@
 # Dockerfile for cerberus in prow
 
-FROM registry.ci.openshift.org/chaos/cerberus:latest
+FROM quay.io/redhat-chaos/cerberus:latest
 
 LABEL maintainer="Red Hat Chaos Engineering Team"
 


### PR DESCRIPTION
Base image for prow was using prow reference registry. Our cerberus main should be the exact same and will help with build errors we were seeing 