### PR TITLE
Adding chmod to base workdir

### DIFF
--- a/cerberus/Dockerfile_prow
+++ b/cerberus/Dockerfile_prow
@@ -17,4 +17,6 @@ ENV PYTHONPATH=/cerberus/packages:$PYTHONPATH PYTHONUNBUFFERED=1
 
 RUN ls
 
+RUN chmod 777  /cerberus
+
 WORKDIR /cerberus


### PR DESCRIPTION
Need to be able to write to the current directory to write the results files from cerberus run

Open to other suggestions/resolutions here

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/42580/rehearse-42580-pull-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.15-nightly-x86-control-plane-3nodes/1726660047506771968
```
2023-11-20 19:13:49,905 [INFO] Completed watching for the specified number of iterations: 1
Traceback (most recent call last):
  File "/root/cerberus/start_cerberus.py", line 599, in <module>
    main(options.cfg)
  File "/root/cerberus/start_cerberus.py", line 558, in main
    record_time(time_tracker)
  File "/root/cerberus/start_cerberus.py", line 73, in record_time
    with open("./time_tracker.json", "w+") as file:
PermissionError: [Errno 13] Permission denied: './time_tracker.json'
```